### PR TITLE
fixing next chapter links for shipping ships

### DIFF
--- a/book-1-python-sql/chapters/SS_API_CREATE_RESOURCES.md
+++ b/book-1-python-sql/chapters/SS_API_CREATE_RESOURCES.md
@@ -12,3 +12,5 @@ def do_POST(self):
 Your job is to follow the same pattern that is being used for GET, PUT, and DELETE operations to allow a client to create a ship, hauler, or dock. You will be using the `INSERT INTO` statement for this operation. Open each of your view files and add a new function for creation operations.
 
 Make sure that this methods accept the POST data as a parameter, just like the update methods do.
+
+[Expand dock chapter >](./SS_API_IMPERATIVE_EXPAND_HAULER_DOCK.md)

--- a/book-1-python-sql/chapters/SS_API_IMPERATIVE_SEQUENCE.md
+++ b/book-1-python-sql/chapters/SS_API_IMPERATIVE_SEQUENCE.md
@@ -76,4 +76,4 @@ Once your team has chosen which tools will be used, use your debugging skills to
 
 When your sequence diagram is complete, you must contact one of your coaches for a review. Once that review is done, and any corrections are made, you can move on to the next chapter.
 
-[Expand dock chapter >](./SS_API_IMPERATIVE_EXPAND_HAULER_DOCK.md)
+[Create Resources Chapter >](./SS_API_CREATE_RESOURCES.md)


### PR DESCRIPTION
In shipping ships, chapter five's "next chapter" link goes to chapter seven. Chapter six does not have a link. 